### PR TITLE
Match search on multiple lines if needed

### DIFF
--- a/webextension/background.js
+++ b/webextension/background.js
@@ -130,7 +130,7 @@ function YOURLS(settings, options, expected) {
 			if (xhr.readyState == 4) {
 				clearTimeout(rqTimer);
 				if ((xhr.status == 200) || (xhr.status == 201)) {
-					var uMatch = xhr.responseText.match (new RegExp(expMatchString));
+					var uMatch = xhr.responseText.match(new RegExp(expMatchString, 'm'));
 					if (uMatch) {
 						resolve ({url: uMatch[1], originalRespons: xhr.responseText});
 					} else {


### PR DESCRIPTION
As the version 1.7.10 of YOURLS returns this body on version action:
```
<?xml version="1.0"?>
<root><version>1.7.10</version></root>
```
We need to search in multiple lines, otherwise it will throw errors
when trying to setup the extension

Kudos for the extension